### PR TITLE
chore: change app name to Eclipse Thingweb App

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eclipse_thingweb_demo_app
+# Eclipse Thingweb App
 
 A new Flutter project.
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.eclipse_thingweb_demo_app"
+    namespace = "com.example.eclipse_thingweb_app"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.eclipse_thingweb_demo_app"
+        applicationId = "com.example.eclipse_thingweb_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="eclipse_thingweb_demo_app"
+        android:label="Eclipse Thingweb"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/kotlin/com/example/ecplise_thingweb_demo_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/ecplise_thingweb_demo_app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.eclipse_thingweb_demo_app
+package com.example.eclipse_thingweb_app
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>eclipse_thingweb_demo_app</string>
+	<string>eclipse_thingweb_app</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,7 @@
 import 'package:dart_wot/binding_mqtt.dart';
 import 'package:dart_wot/binding_http.dart';
 import 'package:dart_wot/core.dart';
-import 'package:eclipse_thingweb_demo_app/pages/graph.dart';
+import 'package:eclipse_thingweb_app/pages/graph.dart';
 import 'package:flex_seed_scheme/flex_seed_scheme.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -43,7 +43,7 @@ class WotApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const title = "Voltage Monitor";
+    const title = "Eclipse Thingweb App";
 
     const thingwebPrimary = Color(0x00067362);
     const thingwebSecondary = Color(0x00B84A91);

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'package:dart_wot/core.dart';
-import 'package:eclipse_thingweb_demo_app/main.dart';
+import 'package:eclipse_thingweb_app/main.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:eclipse_thingweb_demo_app/main.dart';
-import 'package:eclipse_thingweb_demo_app/widgets/input_form.dart';
+import 'package:eclipse_thingweb_app/main.dart';
+import 'package:eclipse_thingweb_app/widgets/input_form.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_settings_ui/flutter_settings_ui.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "eclipse_thingweb_demo_app")
+set(BINARY_NAME "eclipse_thingweb_app")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.eclipse_thingweb_demo_app")
+set(APPLICATION_ID "com.example.eclipse_thingweb_app")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -40,11 +40,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "eclipse_thingweb_demo_app");
+    gtk_header_bar_set_title(header_bar, "eclipse_thingweb_app");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "eclipse_thingweb_demo_app");
+    gtk_window_set_title(window, "eclipse_thingweb_app");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -66,7 +66,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* eclipse_thingweb_demo_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = eclipse_thingweb_demo_app.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* eclipse_thingweb_app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = eclipse_thingweb_app.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -144,7 +144,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* eclipse_thingweb_demo_app.app */,
+				33CC10ED2044A3C60003C045 /* eclipse_thingweb_app.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -249,7 +249,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* eclipse_thingweb_demo_app.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* eclipse_thingweb_app.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -482,7 +482,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.eclipseThingwebDemoApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/eclipse_thingweb_demo_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/eclipse_thingweb_demo_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/eclipse_thingweb_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/eclipse_thingweb_app";
 			};
 			name = Debug;
 		};
@@ -497,7 +497,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.eclipseThingwebDemoApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/eclipse_thingweb_demo_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/eclipse_thingweb_demo_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/eclipse_thingweb_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/eclipse_thingweb_app";
 			};
 			name = Release;
 		};
@@ -512,7 +512,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.eclipseThingwebDemoApp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/eclipse_thingweb_demo_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/eclipse_thingweb_demo_app";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/eclipse_thingweb_app.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/eclipse_thingweb_app";
 			};
 			name = Profile;
 		};

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "eclipse_thingweb_demo_app.app"
+               BuildableName = "eclipse_thingweb_app.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "eclipse_thingweb_demo_app.app"
+            BuildableName = "eclipse_thingweb_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "eclipse_thingweb_demo_app.app"
+            BuildableName = "eclipse_thingweb_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -82,7 +82,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "eclipse_thingweb_demo_app.app"
+            BuildableName = "eclipse_thingweb_app.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = Voltage Monitor
+PRODUCT_NAME = Eclipse Thingweb App
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.example.eclipseThingwebDemoApp

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: eclipse_thingweb_demo_app
+name: eclipse_thingweb_app
 description: "A new Flutter project."
 publish_to: 'none'
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,8 +7,8 @@
 import 'package:dart_wot/core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:eclipse_thingweb_demo_app/main.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:eclipse_thingweb_app/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="eclipse_thingweb_demo_app">
+  <meta name="apple-mobile-web-app-title" content="eclipse_thingweb_app">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>eclipse_thingweb_demo_app</title>
+  <title>eclipse_thingweb_app</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "eclipse_thingweb_demo_app",
-    "short_name": "eclipse_thingweb_demo_app",
+    "name": "eclipse_thingweb_app",
+    "short_name": "eclipse_thingweb_app",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#hexcode",

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Project-level configuration.
 cmake_minimum_required(VERSION 3.14)
-project(eclipse_thingweb_demo_app LANGUAGES CXX)
+project(eclipse_thingweb_app LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "eclipse_thingweb_demo_app")
+set(BINARY_NAME "eclipse_thingweb_app")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "eclipse_thingweb_demo_app" "\0"
+            VALUE "FileDescription", "eclipse_thingweb_app" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
-            VALUE "InternalName", "eclipse_thingweb_demo_app" "\0"
+            VALUE "InternalName", "eclipse_thingweb_app" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2024 com.example. All rights reserved." "\0"
-            VALUE "OriginalFilename", "eclipse_thingweb_demo_app.exe" "\0"
-            VALUE "ProductName", "eclipse_thingweb_demo_app" "\0"
+            VALUE "OriginalFilename", "eclipse_thingweb_app.exe" "\0"
+            VALUE "ProductName", "eclipse_thingweb_app" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"eclipse_thingweb_demo_app", origin, size)) {
+  if (!window.Create(L"eclipse_thingweb_app", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
This PR changes the name of the app as a first step for turning it from a voltage monitor only to a more generic one.